### PR TITLE
Remove exit from Format-Checklist which had been added back in recent…

### DIFF
--- a/src/formatters.ps1
+++ b/src/formatters.ps1
@@ -27,8 +27,7 @@ function writeFail($timestamp, $requirement, $clearString) {
     $color = "Red"
     $message = "$symbol $timestamp $requirement"
     Write-Host "`r$clearString" -NoNewline
-    Write-Host "`n$message`n" -ForegroundColor $color
-    exit -1
+    Write-Host "`r$message" -ForegroundColor $color
 }
 
 $fsm = @{
@@ -41,6 +40,7 @@ $fsm = @{
             }
             "Test Test Stop $false" = {
                 writeFail @args
+                $fsm
             }
         }
     }
@@ -74,6 +74,7 @@ $fsm = @{
                                             }
                                             "TestSet Validate Stop $false" = {
                                                 writeFail @args
+                                                $fsm
                                             }
                                         }
                                     }


### PR DESCRIPTION
… commit

Added to code to allow failed tests to not error

----

If I had a Test with no Set, Format-Checklist will exit the code (and my terminal)
Even with the Exit -1 removed, I would still get the following error without the additional code I added
```
√ 06:39:34 Resource 1 is present in the system  <- Green

X 06:39:34 Resource 2 is present in the system   <- Red

Format-Checklist : Cannot index into a null array.
At line:1 char:11
+ $events | Format-Checklist
+           ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Format-Checklist], RuntimeException
    + FullyQualifiedErrorId : NullArray,Format-Checklist
```
Also, I wasn't sure if the additional spaces arround the red failed message were intentional (maybe to make it standout more?) but they were not needed for my use case so I took them out. 