### PR TITLE
Rename Push-Namespace to New-RequirementGroup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - "*"
-      - "!master"
+on: pull_request
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -1,40 +1,44 @@
+
 ### Breaking changes
+
 #### v2.3
+
 * Requirement nesting is no longer supported.  Requirements are supposed to be atomic components of a system, and by definition, atomic components cannot contain other atomic components and still be atomic. Recommendation is to migrate to our [supported patterns](#patterns).
 * `Format-Callstack`, the formatter for nested Requirements, is no longer supported.  Recommendation is to migrate to [`Format-Verbose`](#format-verbose).
 * `Name` is no longer a supported property on Requirements.  Recommendation is to migrate to [namespaces](#managing-large-configurations-with-namespaces).
 
 -----
 
-- [Overview](#overview)
-  - [What is a Requirement](#what-is-a-requirement)
-  - [Why Requirements](#why-requirements)
-    - [Code against the Desired State](#code-against-the-desired-state)
-    - [Generically define Requirements](#generically-define-requirements)
-  - [Comparison to DSC](#comparison-to-dsc)
-- [Quickstart](#quickstart)
-  - [Defining Requirements](#defining-requirements)
-    - [Note: `Describe` the desired state, not the transition](#note-describe-the-desired-state-not-the-transition)
-  - [Enforcing the Configuration](#enforcing-the-configuration)
-- [Advanced Configurations](#advanced-configurations)
-  - [Types of Requirements](#types-of-requirements)
-    - [Standard Requirement](#standard-requirement)
-    - [Validation Requirements](#validation-requirements)
-    - [Idempotent `Set` Requirements](#idempotent-set-requirements)
-  - [Patterns](#patterns)
-    - [Avoiding state with selectors](#avoiding-state-with-selectors)
-    - [Reusable requirements](#reusable-requirements)
-    - [Defining Requirements with control flow](#defining-requirements-with-control-flow)
-    - [Managing large configurations with Namespaces](#managing-large-configurations-with-namespaces)
-    - [Isomorphic Enforcement](#isomorphic-enforcement)
-  - [Defining DSC Resources](#defining-dsc-resources)
-- [Formatting the logs](#formatting-the-logs)
-  - [`Format-Table`](#format-table)
-  - [`Format-Checklist`](#format-checklist)
-  - [`Format-Verbose`](#format-verbose)
-- [Contributing](#contributing)
+* [Overview](#overview)
+  * [What is a Requirement](#what-is-a-requirement)
+  * [Why Requirements](#why-requirements)
+    * [Code against the Desired State](#code-against-the-desired-state)
+    * [Generically define Requirements](#generically-define-requirements)
+  * [Comparison to DSC](#comparison-to-dsc)
+* [Quickstart](#quickstart)
+  * [Defining Requirements](#defining-requirements)
+    * [Note: `Describe` the desired state, not the transition](#note-describe-the-desired-state-not-the-transition)
+  * [Enforcing the Configuration](#enforcing-the-configuration)
+* [Advanced Configurations](#advanced-configurations)
+  * [Types of Requirements](#types-of-requirements)
+    * [Standard Requirement](#standard-requirement)
+    * [Validation Requirements](#validation-requirements)
+    * [Idempotent `Set` Requirements](#idempotent-set-requirements)
+  * [Patterns](#patterns)
+    * [Avoiding state with selectors](#avoiding-state-with-selectors)
+    * [Reusable requirements](#reusable-requirements)
+    * [Defining Requirements with control flow](#defining-requirements-with-control-flow)
+    * [Managing large configurations with Namespaces](#managing-large-configurations-with-namespaces)
+    * [Isomorphic Enforcement](#isomorphic-enforcement)
+  * [Defining DSC Resources](#defining-dsc-resources)
+* [Formatting the logs](#formatting-the-logs)
+  * [`Format-Table`](#format-table)
+  * [`Format-Checklist`](#format-checklist)
+  * [`Format-Verbose`](#format-verbose)
+* [Contributing](#contributing)
 
 # Overview
+
 Requirements is a PowerShell Gallery module for declaratively describing a system as a set of "requirements", then idempotently setting each requirement to its desired state.
 
 The background motivation and implementation design are discussed in detail in [Declarative Idempotency](https://itnext.io/declarative-idempotency-aaa07c6dd9a0?source=friends_link&sk=f0464e8e29525b23aabe766bfb557dd7).
@@ -42,9 +46,11 @@ The background motivation and implementation design are discussed in detail in [
 Trevor Sullivan provides a good overview and (slightly outdated) tutorial [video](https://www.youtube.com/watch?v=efRnjlZKCGw) about Requirements.
 
 ## What is a Requirement
+
 A "Requirement" is a single atomic component of a system configuration.  For a system to be in its desired state, all Requirements in the system must be in a desired state.
 
 A Requirement is an object defined by three properties:
+
 * `Describe` - A `string` that describes the desired state of the Requirement.
 * `Test` - A `scriptblock` that returns whether the Requirement is in its desired state.
 * `Set` - A `scriptblock` that can be run to put the Requirement into its desired state if it is not in a desired state.
@@ -52,19 +58,24 @@ A Requirement is an object defined by three properties:
 ## Why Requirements
 
 ### Code against the Desired State
+
 In DevOps, you may be managing a fleet of servers, containers, cloud resources, files on disk, or many other kinds of components in a heterogeneous system.  Lets say you have *n* components in your system and every component is either in a `GOOD` or `BAD` state.  You have two options:
+
 * You can try and account for every possible configuration of your system and transition between those states, but then you will have *2**n* possible states to manage.
 * You can only account for the desired state of each individual component, so you will only have *n* states to account for.  Much simpler!
 
 ### Generically define Requirements
+
 If you only manage cloud resources, then try to use Terraform, ARM, or CloudFormation.  If you only manage kubernetes resources, then try and use Helm.  These are domain-specific frameworks for managing the desired state of resources and are best suited for their task.
 
 However, you will often find you have complex configurations, such as configurations that can only be described in PowerShell.  You may even have macroconfigurations that consist of one or more Terraform templates.  In this case you will probably want something more generic to glue your configurations together without sacrificing the declarative desired state paradigm.  This is where Requirements comes in.
 
 ## Comparison to DSC
+
 Desired State Configurations allow you to declaratively describe a configuration, then let the local configuration manager handle with setting the configuration to its desired state.  This pattern from the outside may seem similar to Requirements, but there are crucial differences.
 
 DSC is optimized for handling *many* configurations *asynchronously*.  For example, applying a configuration in parallel to multiple nodes.  In contrast, Requirements applies a *single* configuration *synchronously*.  This enables usage in different scenarios, including:
+
 * CI/CD scripts
 * CLIs
 * Dockerfiles
@@ -72,10 +83,10 @@ DSC is optimized for handling *many* configurations *asynchronously*.  For examp
 
 While Requirements supports DSC resources, it does not have a hard dependency on DSC's configuration manager, so if your Requirements do not include DSC resources they will work on any platform that PowerShell Core supports.
 
-
 # Quickstart
 
 ## Defining Requirements
+
 The easiest way to declare a requirement is to define it as a hashtable and let PowerShell's implicit casting handle the rest.
 
 ```powershell
@@ -93,7 +104,7 @@ $requirements = @(
         Test     = { $mySystem -contains 2 }
         Set      = {
             $mySystem.Add(2) | Out-Null
-            Start-Sleep 1 
+            Start-Sleep 1
         }
     },
     @{
@@ -101,18 +112,20 @@ $requirements = @(
         Test     = { $mySystem -contains 3 }
         Set      = {
             $mySystem.Add(3) | Out-Null
-            Start-Sleep 1 
+            Start-Sleep 1
         }
     }
 )
 ```
 
 ### Note: `Describe` the desired state, not the transition
+
 Our `Describe` describes the *desired state* of the Requirement (ex: "Resource 1 is present in the system") and not the `Set` block's transitioning action (ex: "Adding Resource 1 to the system").  This is because the `Set` block is not called if the Requirement is already in its desired state, so if we used the latter `Describe` and Resource 1 was already present in the system, we would be inaccurately logging that the Requirement is modifying the system when it is actually taking no action.
 
 The sooner you embrace the Desired State mindset, the less friction you will have writing Requirements and managing your complex system configurations.
 
 ## Enforcing the Configuration
+
 Once you have an array of Requirements, you can simply pipe the Requirements into `Invoke-Requirement` to put each Requirement into its desired state.
 
 ```powershell
@@ -124,12 +137,15 @@ The status of each Requirement will be logged to the output stream.  By default 
 # Advanced Configurations
 
 ## Types of Requirements
+
 As you learned [previously](#what-is-a-requirement), Requirements consist of `Describe`, `Test`, and `Set` properties.  There are 4 types of Requirements--one for every permutation of including or excluding `Test` and `Set`.  Note that `Describe` must always be present.
 
 ### Standard Requirement
+
 This is the kind you are already [familiar with](#what-is-a-requirement).  It includes both a `Test` and `Set`.
 
 ### Validation Requirements
+
 If you wish to assert that a precondition is met before continuing, you can leave out the `Set` block.  This is useful for [Defensive programming](https://itnext.io/defensive-powershell-with-validation-attributes-8e7303e179fd?source=friends_link&sk=14765ca9554709a77f8af7d73612ef5b), or when a Requirement requires manual steps.
 
 ```powershell
@@ -140,6 +156,7 @@ If you wish to assert that a precondition is met before continuing, you can leav
 ```
 
 ### Idempotent `Set` Requirements
+
 Sometimes, your `Set` block is already idempotent and an associated `Test` block cannot be defined.  In this case, you can leave out the `Test` block.
 
 ```powershell
@@ -150,9 +167,11 @@ Sometimes, your `Set` block is already idempotent and an associated `Test` block
 ```
 
 ## Patterns
+
 Some people have trouble managing large configurations with Requirements because they try and explicitly define a single array literal of Requirements; however, this is unnecessary and Requirements can be handled like any other PowerShell object.  Here are some examples of patterns for managing Requirements.
 
 ### Avoiding state with selectors
+
 Requirements should strongly avoid maintaining internal state.  Requirements is for enforcing declarative programming, whereas maintaining state is an imperative loophole that breaks the declarative paradigm.
 
 Instead, use **selectors** to easily derive up-to-date properties of the system using unit-testable functions.
@@ -178,6 +197,7 @@ function New-StorageAccountRequirement {
 ```
 
 ### Reusable requirements
+
 You can wrap Requirements in a parameterized function or script to avoid redifining Requirements--
 
 ```powershell
@@ -187,7 +207,7 @@ function New-ResourceGroupRequirement {
         [string]$Location
     )
 
-    Push-Namespace "rg" {
+    New-RequirementGroup "rg" {
         @{
             Describe = "Logged in to Azure"
             Test     = { Get-AzAccount }
@@ -221,6 +241,7 @@ $Location = "West US 2"
 ```
 
 ### Defining Requirements with control flow
+
 Using control flow statements, like `if` and `foreach`, can dramatically simplify your Requirement definitions.  Let's see if we can simiplify our [quickstart example](#defining-requirements).
 
 ```powershell
@@ -235,14 +256,15 @@ foreach ($resourceId in 1..3) {
 
 Notice that we had to call `.GetNewClosure()` to capture the current value of `$resourceId` in the `scriptblock`--otherwise the value would be `3` or `$null` depending on where we invoked it.
 
-When you define Requirements with control flow in this manner, the Requirements are written to output.  As such, this logic should be wrapped in a script, function, or `scriptblock`. 
+When you define Requirements with control flow in this manner, the Requirements are written to output.  As such, this logic should be wrapped in a script, function, or `scriptblock`.
 
 ### Managing large configurations with Namespaces
-You can group Requirements into namespaces for clearer logging.  To add a namespace to Requirements, use the `Push-Namespace` function.  You can nest namespaces as well.
+
+You can group Requirements into namespaces for clearer logging.  To add a namespace to Requirements, use the `New-RequirementGroup` function.  You can nest namespaces as well.
 
 ```powershell
-Push-Namespace "local" {
-    Push-Namespace "clis" {
+New-RequirementGroup "local" {
+    New-RequirementGroup "clis" {
         @{
             Describe = "az is installed"
             Test     = { ... }
@@ -254,21 +276,21 @@ Push-Namespace "local" {
             Set      = { ... }
         }
     }
-    Push-Namespace "configs" {
+    New-RequirementGroup "configs" {
         @{
             Describe = "cluster config is built"
             Test     = { ... }
             Set      = { ... }
         }
     }
-}
-Push-Namespace "cloud" {
+} | Invoke-Requirement | Format-Checklist
+New-RequirementGroup "cloud" {
     @{
         Describe = "Terraform is deployed"
         Test     = { ... }
         Set      = { ... }
     }
-}
+} | Invoke-Requirement | Format-Checklist
 ```
 
 The above example would result in the Requirements below.
@@ -283,20 +305,26 @@ cloud         Terraform is deployed
 ```
 
 ### Isomorphic Enforcement
+
 Isomorphic execution means that our Requirements are enforced the same regardless of what context they are enforced in.  You will want your Requirements to run in a CICD pipeline for safe deployment practices and run manually from your local machine for development purposes, but in both contexts the Requirements should run exactly the same.
 
 We will accomplish this by implementing Separation of Concerns, separating our Requirement definitions from our execution logic:
+
 * `myrequirements.ps1`, which will return an array of Requirements.
 * `Invoke-Verbose.ps1`, which will be called in a CICD pipeline and write verbose status information to the output stream.
+
     ```powershell
     ./myrequirements.ps1 | Invoke-Requirement | Format-Verbose
     ```
+
 * `Invoke-Checklist.ps1`, which will be called in a console and interactively write to the host.
+
     ```powershell
     ./myrequirements.ps1 | Invoke-Requirement | Format-Checklist
     ```
 
 ## Defining DSC Resources
+
 If you're using Windows and PowerShell 5, you can use DSC resources with Requirements.
 
 ```PowerShell
@@ -314,14 +342,17 @@ New-Requirement @requirement | Invoke-Requirement | Format-Checklist
 ```
 
 # Formatting the logs
-`Invoke-Requirement` will output logging events for each step in a `Requirement`'s execution lifecycle.  You can capture these logs with `Format-Table` or `Format-List`, or 
+
+`Invoke-Requirement` will output logging events for each step in a `Requirement`'s execution lifecycle.  You can capture these logs with `Format-Table` or `Format-List`, or
 
 ```powershell
 $requirements | Invoke-Requirement | Format-Table
 ```
 
 ## `Format-Table`
+
 These logs were using `-Autosize` parameter, which better formats the columns, but does not support outputting as a stream.
+
 ```
   Method Lifecycle Name       Date
   ------ --------- ----       ----
@@ -338,11 +369,13 @@ Validate      Stop Resource 1 6/12/2019 12:00:26 PM
 ```
 
 ## `Format-Checklist`
+
 `Format-Checklist` will present a live-updating checklist to the user.
 
 ![Format-Checklist output](https://raw.githubusercontent.com/microsoft/requirements/master/imgs/checklist.png)
 
 ## `Format-Verbose`
+
 Unlike `Format-Checklist`, `Format-Verbose` prints all log events and includes metadata.  For complex use cases, you can define nested `Requirement`s (`Requirement`s that contain more `Requirement`s in their `Set` block).  `Format-Verbose` will print the stack of `Requirement` names of each `Requirement` as its processed.
 
 ![Format-Verbose output](https://raw.githubusercontent.com/microsoft/requirements/master/imgs/callstack.png)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ function New-ResourceGroupRequirement {
         [string]$Location
     )
 
-    New-RequirementGroup "rg" {
+    New-RequirementGroup "rg" -ScriptBlock {
         @{
             Describe = "Logged in to Azure"
             Test     = { Get-AzAccount }
@@ -283,14 +283,14 @@ New-RequirementGroup "local" {
             Set      = { ... }
         }
     }
-} | Invoke-Requirement | Format-Checklist
+}
 New-RequirementGroup "cloud" {
     @{
         Describe = "Terraform is deployed"
         Test     = { ... }
         Set      = { ... }
     }
-} | Invoke-Requirement | Format-Checklist
+}
 ```
 
 The above example would result in the Requirements below.

--- a/Requirements.psd1
+++ b/Requirements.psd1
@@ -68,7 +68,7 @@
         'Format-Verbose',
         'Invoke-Requirement',
         'New-Requirement',
-        'Push-Namespace',
+        'New-RequirementGroup',
         'Set-Requirement',
         'Test-Requirement'
     )
@@ -80,7 +80,9 @@
     VariablesToExport = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport   = @()
+    AliasesToExport   = @(
+        'Push-Namespace'
+    )
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/src/interface.ps1
+++ b/src/interface.ps1
@@ -130,10 +130,10 @@ function Set-Requirement {
 
 <#
 .SYNOPSIS
-    Prepends a namespace to the Requirements' name
+    Creates a Group of Requirements
 #>
-function Push-Namespace {
-  [CmdletBinding()]
+function New-RequirementGroup {
+  [CmdletBinding(SupportsShouldProcess)]
   Param(
     # The namespace identifier
     [Parameter(Mandatory, Position = 0)]
@@ -142,7 +142,7 @@ function Push-Namespace {
     [Parameter(Mandatory, Position = 1, ParameterSetName = "scriptblock")]
     [ValidateNotNullOrEmpty()]
     [scriptblock]$ScriptBlock,
-    # The array of Requirements to add under the new namespace
+    # The array of Requirements to add under the new Group
     [Parameter(Mandatory, Position = 1, ParameterSetName = "requirements")]
     [ValidateNotNullOrEmpty()]
     [Requirement[]]$Requirement
@@ -159,3 +159,6 @@ function Push-Namespace {
     $r
   }
 }
+
+# Set alias to ensure backwards compatibility
+New-Alias -Name New-RequirementGroup -Value Push-Namespace

--- a/src/interface.ps1
+++ b/src/interface.ps1
@@ -137,7 +137,9 @@ function New-RequirementGroup {
   Param(
     # The namespace identifier
     [Parameter(Mandatory, Position = 0)]
-    [string]$Namespace,
+    [Alias("Namespace")]
+    [ValidateNotNullOrEmpty()]
+    [string]$Name,
     # A scriptblock that writes Requirements to output when invoked
     [Parameter(Mandatory, Position = 1, ParameterSetName = "scriptblock")]
     [ValidateNotNullOrEmpty()]

--- a/src/interface.ps1
+++ b/src/interface.ps1
@@ -133,7 +133,8 @@ function Set-Requirement {
     Creates a Group of Requirements
 #>
 function New-RequirementGroup {
-  [CmdletBinding(SupportsShouldProcess)]
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+  [CmdletBinding()]
   [Alias("Push-Namespace")]
   Param(
     # The namespace identifier

--- a/src/interface.ps1
+++ b/src/interface.ps1
@@ -134,6 +134,7 @@ function Set-Requirement {
 #>
 function New-RequirementGroup {
   [CmdletBinding(SupportsShouldProcess)]
+  [Alias("Push-Namespace")]
   Param(
     # The namespace identifier
     [Parameter(Mandatory, Position = 0)]
@@ -161,6 +162,3 @@ function New-RequirementGroup {
     $r
   }
 }
-
-# Set alias to ensure backwards compatibility
-New-Alias -Name New-RequirementGroup -Value Push-Namespace

--- a/src/module.psm1
+++ b/src/module.psm1
@@ -1,2 +1,2 @@
 
-."$PSScriptRoot\interface.ps1"
+."$PSScriptRoot\interface.ps1" 

--- a/src/module.psm1
+++ b/src/module.psm1
@@ -1,2 +1,2 @@
 
-."$PSScriptRoot\interface.ps1" 
+."$PSScriptRoot\interface.ps1"

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  12:00:57 ns>MyDescribe
+  12:29:47 ns>MyDescribe
                         
-√ 12:00:57 ns>MyDescribe
+√ 12:29:47 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  08:02:37 ns>MyDescribe
+  08:15:24 ns>MyDescribe
                         
-√ 08:02:37 ns>MyDescribe
+√ 08:15:24 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  08:21:28 ns>MyDescribe
+  09:44:13 ns>MyDescribe
                         
-√ 08:21:28 ns>MyDescribe
+√ 09:44:13 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  05:11:10 ns>MyDescribe
+  05:16:31 ns>MyDescribe
                         
-√ 05:11:10 ns>MyDescribe
+√ 05:16:31 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  12:29:47 ns>MyDescribe
+  08:02:37 ns>MyDescribe
                         
-√ 12:29:47 ns>MyDescribe
+√ 08:02:37 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  05:05:38 ns>MyDescribe
+  05:11:10 ns>MyDescribe
                         
-√ 05:05:38 ns>MyDescribe
+√ 05:11:10 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  11:58:32 ns>MyDescribe
+  12:00:57 ns>MyDescribe
                         
-√ 11:58:32 ns>MyDescribe
+√ 12:00:57 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  08:15:24 ns>MyDescribe
+  05:05:38 ns>MyDescribe
                         
-√ 08:15:24 ns>MyDescribe
+√ 05:05:38 ns>MyDescribe

--- a/test/integration/Format-Checklist.Set.txt
+++ b/test/integration/Format-Checklist.Set.txt
@@ -1,3 +1,3 @@
-  09:44:13 ns>MyDescribe
+  11:58:32 ns>MyDescribe
                         
-√ 09:44:13 ns>MyDescribe
+√ 11:58:32 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  12:00:57 ns>MyDescribe
+  12:29:47 ns>MyDescribe
                         
-√ 12:00:57 ns>MyDescribe
+√ 12:29:47 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  08:02:37 ns>MyDescribe
+  08:15:24 ns>MyDescribe
                         
-√ 08:02:37 ns>MyDescribe
+√ 08:15:24 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  08:21:27 ns>MyDescribe
+  09:44:13 ns>MyDescribe
                         
-√ 08:21:27 ns>MyDescribe
+√ 09:44:13 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  05:11:10 ns>MyDescribe
+  05:16:31 ns>MyDescribe
                         
-√ 05:11:10 ns>MyDescribe
+√ 05:16:31 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  12:29:47 ns>MyDescribe
+  08:02:37 ns>MyDescribe
                         
-√ 12:29:47 ns>MyDescribe
+√ 08:02:37 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  05:05:38 ns>MyDescribe
+  05:11:10 ns>MyDescribe
                         
-√ 05:05:38 ns>MyDescribe
+√ 05:11:10 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  11:58:32 ns>MyDescribe
+  12:00:57 ns>MyDescribe
                         
-√ 11:58:32 ns>MyDescribe
+√ 12:00:57 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  08:15:24 ns>MyDescribe
+  05:05:38 ns>MyDescribe
                         
-√ 08:15:24 ns>MyDescribe
+√ 05:05:38 ns>MyDescribe

--- a/test/integration/Format-Checklist.Test.txt
+++ b/test/integration/Format-Checklist.Test.txt
@@ -1,3 +1,3 @@
-  09:44:13 ns>MyDescribe
+  11:58:32 ns>MyDescribe
                         
-√ 09:44:13 ns>MyDescribe
+√ 11:58:32 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  12:00:57 ns>MyDescribe
+  12:29:47 ns>MyDescribe
                         
-√ 12:00:57 ns>MyDescribe
+√ 12:29:47 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  08:02:37 ns>MyDescribe
+  08:15:24 ns>MyDescribe
                         
-√ 08:02:37 ns>MyDescribe
+√ 08:15:24 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  08:21:27 ns>MyDescribe
+  09:44:13 ns>MyDescribe
                         
-√ 08:21:27 ns>MyDescribe
+√ 09:44:13 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  05:11:10 ns>MyDescribe
+  05:16:31 ns>MyDescribe
                         
-√ 05:11:10 ns>MyDescribe
+√ 05:16:31 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  12:29:47 ns>MyDescribe
+  08:02:37 ns>MyDescribe
                         
-√ 12:29:47 ns>MyDescribe
+√ 08:02:37 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  05:05:38 ns>MyDescribe
+  05:11:10 ns>MyDescribe
                         
-√ 05:05:38 ns>MyDescribe
+√ 05:11:10 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  11:58:32 ns>MyDescribe
+  12:00:57 ns>MyDescribe
                         
-√ 11:58:32 ns>MyDescribe
+√ 12:00:57 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  08:15:24 ns>MyDescribe
+  05:05:38 ns>MyDescribe
                         
-√ 08:15:24 ns>MyDescribe
+√ 05:05:38 ns>MyDescribe

--- a/test/integration/Format-Checklist.TestSet.txt
+++ b/test/integration/Format-Checklist.TestSet.txt
@@ -1,3 +1,3 @@
-  09:44:13 ns>MyDescribe
+  11:58:32 ns>MyDescribe
                         
-√ 09:44:13 ns>MyDescribe
+√ 11:58:32 ns>MyDescribe

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
 Date                Method State Result Requirement
 ----                ------ ----- ------ -----------
-12/3/19 11:58:32 AM    Set Start        ns>MyDescribe
-12/3/19 11:58:32 AM    Set  Stop True   ns>MyDescribe
+12/3/19 12:00:57 PM    Set Start        ns>MyDescribe
+12/3/19 12:00:57 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
-Date               Method State Result Requirement
-----               ------ ----- ------ -----------
-12/3/19 8:15:24 PM    Set Start        ns>MyDescribe
-12/3/19 8:15:24 PM    Set  Stop True   ns>MyDescribe
+Date                 Method State Result Requirement
+----                 ------ ----- ------ -----------
+12/9/2019 5:05:38 PM    Set Start        ns>MyDescribe
+12/9/2019 5:05:38 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
 Date                Method State Result Requirement
 ----                ------ ----- ------ -----------
-12/3/19 12:00:57 PM    Set Start        ns>MyDescribe
-12/3/19 12:00:57 PM    Set  Stop True   ns>MyDescribe
+12/3/19 12:29:47 PM    Set Start        ns>MyDescribe
+12/3/19 12:29:47 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
 Date                 Method State Result Requirement
 ----                 ------ ----- ------ -----------
-12/9/2019 5:05:38 PM    Set Start        ns>MyDescribe
-12/9/2019 5:05:38 PM    Set  Stop True   ns>MyDescribe
+12/9/2019 5:11:10 PM    Set Start        ns>MyDescribe
+12/9/2019 5:11:10 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
 Date                 Method State Result Requirement
 ----                 ------ ----- ------ -----------
-12/9/2019 5:11:10 PM    Set Start        ns>MyDescribe
-12/9/2019 5:11:10 PM    Set  Stop True   ns>MyDescribe
+12/9/2019 5:16:31 PM    Set Start        ns>MyDescribe
+12/9/2019 5:16:31 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
-Date               Method State Result Requirement
-----               ------ ----- ------ -----------
-12/2/19 9:44:13 PM    Set Start        ns>MyDescribe
-12/2/19 9:44:13 PM    Set  Stop True   ns>MyDescribe
+Date                Method State Result Requirement
+----                ------ ----- ------ -----------
+12/3/19 11:58:32 AM    Set Start        ns>MyDescribe
+12/3/19 11:58:32 AM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
-Date                  Method State Result Requirement
-----                  ------ ----- ------ -----------
-11/26/2019 8:21:28 PM    Set Start        ns>MyDescribe
-11/26/2019 8:21:28 PM    Set  Stop True   ns>MyDescribe
+Date               Method State Result Requirement
+----               ------ ----- ------ -----------
+12/2/19 9:44:13 PM    Set Start        ns>MyDescribe
+12/2/19 9:44:13 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
-Date                Method State Result Requirement
-----                ------ ----- ------ -----------
-12/3/19 12:29:47 PM    Set Start        ns>MyDescribe
-12/3/19 12:29:47 PM    Set  Stop True   ns>MyDescribe
+Date               Method State Result Requirement
+----               ------ ----- ------ -----------
+12/3/19 8:02:37 PM    Set Start        ns>MyDescribe
+12/3/19 8:02:37 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Set.txt
+++ b/test/integration/Format-Table.Set.txt
@@ -1,6 +1,6 @@
 
 Date               Method State Result Requirement
 ----               ------ ----- ------ -----------
-12/3/19 8:02:37 PM    Set Start        ns>MyDescribe
-12/3/19 8:02:37 PM    Set  Stop True   ns>MyDescribe
+12/3/19 8:15:24 PM    Set Start        ns>MyDescribe
+12/3/19 8:15:24 PM    Set  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
 Date                Method State Result Requirement
 ----                ------ ----- ------ -----------
-12/3/19 11:58:32 AM   Test Start        ns>MyDescribe
-12/3/19 11:58:32 AM   Test  Stop True   ns>MyDescribe
+12/3/19 12:00:57 PM   Test Start        ns>MyDescribe
+12/3/19 12:00:57 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
-Date               Method State Result Requirement
-----               ------ ----- ------ -----------
-12/3/19 8:15:24 PM   Test Start        ns>MyDescribe
-12/3/19 8:15:24 PM   Test  Stop True   ns>MyDescribe
+Date                 Method State Result Requirement
+----                 ------ ----- ------ -----------
+12/9/2019 5:05:38 PM   Test Start        ns>MyDescribe
+12/9/2019 5:05:38 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
-Date                Method State Result Requirement
-----                ------ ----- ------ -----------
-12/3/19 12:29:47 PM   Test Start        ns>MyDescribe
-12/3/19 12:29:47 PM   Test  Stop True   ns>MyDescribe
+Date               Method State Result Requirement
+----               ------ ----- ------ -----------
+12/3/19 8:02:37 PM   Test Start        ns>MyDescribe
+12/3/19 8:02:37 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
 Date               Method State Result Requirement
 ----               ------ ----- ------ -----------
-12/3/19 8:02:37 PM   Test Start        ns>MyDescribe
-12/3/19 8:02:37 PM   Test  Stop True   ns>MyDescribe
+12/3/19 8:15:24 PM   Test Start        ns>MyDescribe
+12/3/19 8:15:24 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
 Date                Method State Result Requirement
 ----                ------ ----- ------ -----------
-12/3/19 12:00:57 PM   Test Start        ns>MyDescribe
-12/3/19 12:00:57 PM   Test  Stop True   ns>MyDescribe
+12/3/19 12:29:47 PM   Test Start        ns>MyDescribe
+12/3/19 12:29:47 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
-Date               Method State Result Requirement
-----               ------ ----- ------ -----------
-12/2/19 9:44:13 PM   Test Start        ns>MyDescribe
-12/2/19 9:44:13 PM   Test  Stop True   ns>MyDescribe
+Date                Method State Result Requirement
+----                ------ ----- ------ -----------
+12/3/19 11:58:32 AM   Test Start        ns>MyDescribe
+12/3/19 11:58:32 AM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
 Date                 Method State Result Requirement
 ----                 ------ ----- ------ -----------
-12/9/2019 5:05:38 PM   Test Start        ns>MyDescribe
-12/9/2019 5:05:38 PM   Test  Stop True   ns>MyDescribe
+12/9/2019 5:11:10 PM   Test Start        ns>MyDescribe
+12/9/2019 5:11:10 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
-Date                  Method State Result Requirement
-----                  ------ ----- ------ -----------
-11/26/2019 8:21:27 PM   Test Start        ns>MyDescribe
-11/26/2019 8:21:27 PM   Test  Stop True   ns>MyDescribe
+Date               Method State Result Requirement
+----               ------ ----- ------ -----------
+12/2/19 9:44:13 PM   Test Start        ns>MyDescribe
+12/2/19 9:44:13 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.Test.txt
+++ b/test/integration/Format-Table.Test.txt
@@ -1,6 +1,6 @@
 
 Date                 Method State Result Requirement
 ----                 ------ ----- ------ -----------
-12/9/2019 5:11:10 PM   Test Start        ns>MyDescribe
-12/9/2019 5:11:10 PM   Test  Stop True   ns>MyDescribe
+12/9/2019 5:16:31 PM   Test Start        ns>MyDescribe
+12/9/2019 5:16:31 PM   Test  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
-Date                  Method State Result Requirement
-----                  ------ ----- ------ -----------
-12/3/19 12:29:47 PM     Test Start        ns>MyDescribe
-12/3/19 12:29:47 PM     Test  Stop False  ns>MyDescribe
-12/3/19 12:29:47 PM      Set Start        ns>MyDescribe
-12/3/19 12:29:47 PM      Set  Stop True   ns>MyDescribe
-12/3/19 12:29:47 PM Validate Start        ns>MyDescribe
-12/3/19 12:29:47 PM Validate  Stop True   ns>MyDescribe
+Date                 Method State Result Requirement
+----                 ------ ----- ------ -----------
+12/3/19 8:02:37 PM     Test Start        ns>MyDescribe
+12/3/19 8:02:37 PM     Test  Stop False  ns>MyDescribe
+12/3/19 8:02:37 PM      Set Start        ns>MyDescribe
+12/3/19 8:02:37 PM      Set  Stop True   ns>MyDescribe
+12/3/19 8:02:37 PM Validate Start        ns>MyDescribe
+12/3/19 8:02:37 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
 Date                   Method State Result Requirement
 ----                   ------ ----- ------ -----------
-12/9/2019 5:11:10 PM     Test Start        ns>MyDescribe
-12/9/2019 5:11:10 PM     Test  Stop False  ns>MyDescribe
-12/9/2019 5:11:10 PM      Set Start        ns>MyDescribe
-12/9/2019 5:11:10 PM      Set  Stop True   ns>MyDescribe
-12/9/2019 5:11:10 PM Validate Start        ns>MyDescribe
-12/9/2019 5:11:10 PM Validate  Stop True   ns>MyDescribe
+12/9/2019 5:16:31 PM     Test Start        ns>MyDescribe
+12/9/2019 5:16:31 PM     Test  Stop False  ns>MyDescribe
+12/9/2019 5:16:31 PM      Set Start        ns>MyDescribe
+12/9/2019 5:16:31 PM      Set  Stop True   ns>MyDescribe
+12/9/2019 5:16:31 PM Validate Start        ns>MyDescribe
+12/9/2019 5:16:31 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
-Date                    Method State Result Requirement
-----                    ------ ----- ------ -----------
-11/26/2019 8:21:27 PM     Test Start        ns>MyDescribe
-11/26/2019 8:21:27 PM     Test  Stop False  ns>MyDescribe
-11/26/2019 8:21:27 PM      Set Start        ns>MyDescribe
-11/26/2019 8:21:27 PM      Set  Stop True   ns>MyDescribe
-11/26/2019 8:21:27 PM Validate Start        ns>MyDescribe
-11/26/2019 8:21:27 PM Validate  Stop True   ns>MyDescribe
+Date                 Method State Result Requirement
+----                 ------ ----- ------ -----------
+12/2/19 9:44:13 PM     Test Start        ns>MyDescribe
+12/2/19 9:44:13 PM     Test  Stop False  ns>MyDescribe
+12/2/19 9:44:13 PM      Set Start        ns>MyDescribe
+12/2/19 9:44:13 PM      Set  Stop True   ns>MyDescribe
+12/2/19 9:44:13 PM Validate Start        ns>MyDescribe
+12/2/19 9:44:13 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
-Date                 Method State Result Requirement
-----                 ------ ----- ------ -----------
-12/3/19 8:15:24 PM     Test Start        ns>MyDescribe
-12/3/19 8:15:24 PM     Test  Stop False  ns>MyDescribe
-12/3/19 8:15:24 PM      Set Start        ns>MyDescribe
-12/3/19 8:15:24 PM      Set  Stop True   ns>MyDescribe
-12/3/19 8:15:24 PM Validate Start        ns>MyDescribe
-12/3/19 8:15:24 PM Validate  Stop True   ns>MyDescribe
+Date                   Method State Result Requirement
+----                   ------ ----- ------ -----------
+12/9/2019 5:05:38 PM     Test Start        ns>MyDescribe
+12/9/2019 5:05:38 PM     Test  Stop False  ns>MyDescribe
+12/9/2019 5:05:38 PM      Set Start        ns>MyDescribe
+12/9/2019 5:05:38 PM      Set  Stop True   ns>MyDescribe
+12/9/2019 5:05:38 PM Validate Start        ns>MyDescribe
+12/9/2019 5:05:38 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
 Date                  Method State Result Requirement
 ----                  ------ ----- ------ -----------
-12/3/19 12:00:57 PM     Test Start        ns>MyDescribe
-12/3/19 12:00:57 PM     Test  Stop False  ns>MyDescribe
-12/3/19 12:00:57 PM      Set Start        ns>MyDescribe
-12/3/19 12:00:57 PM      Set  Stop True   ns>MyDescribe
-12/3/19 12:00:57 PM Validate Start        ns>MyDescribe
-12/3/19 12:00:57 PM Validate  Stop True   ns>MyDescribe
+12/3/19 12:29:47 PM     Test Start        ns>MyDescribe
+12/3/19 12:29:47 PM     Test  Stop False  ns>MyDescribe
+12/3/19 12:29:47 PM      Set Start        ns>MyDescribe
+12/3/19 12:29:47 PM      Set  Stop True   ns>MyDescribe
+12/3/19 12:29:47 PM Validate Start        ns>MyDescribe
+12/3/19 12:29:47 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
 Date                  Method State Result Requirement
 ----                  ------ ----- ------ -----------
-12/3/19 11:58:32 AM     Test Start        ns>MyDescribe
-12/3/19 11:58:32 AM     Test  Stop False  ns>MyDescribe
-12/3/19 11:58:32 AM      Set Start        ns>MyDescribe
-12/3/19 11:58:32 AM      Set  Stop True   ns>MyDescribe
-12/3/19 11:58:32 AM Validate Start        ns>MyDescribe
-12/3/19 11:58:32 AM Validate  Stop True   ns>MyDescribe
+12/3/19 12:00:57 PM     Test Start        ns>MyDescribe
+12/3/19 12:00:57 PM     Test  Stop False  ns>MyDescribe
+12/3/19 12:00:57 PM      Set Start        ns>MyDescribe
+12/3/19 12:00:57 PM      Set  Stop True   ns>MyDescribe
+12/3/19 12:00:57 PM Validate Start        ns>MyDescribe
+12/3/19 12:00:57 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
 Date                 Method State Result Requirement
 ----                 ------ ----- ------ -----------
-12/3/19 8:02:37 PM     Test Start        ns>MyDescribe
-12/3/19 8:02:37 PM     Test  Stop False  ns>MyDescribe
-12/3/19 8:02:37 PM      Set Start        ns>MyDescribe
-12/3/19 8:02:37 PM      Set  Stop True   ns>MyDescribe
-12/3/19 8:02:37 PM Validate Start        ns>MyDescribe
-12/3/19 8:02:37 PM Validate  Stop True   ns>MyDescribe
+12/3/19 8:15:24 PM     Test Start        ns>MyDescribe
+12/3/19 8:15:24 PM     Test  Stop False  ns>MyDescribe
+12/3/19 8:15:24 PM      Set Start        ns>MyDescribe
+12/3/19 8:15:24 PM      Set  Stop True   ns>MyDescribe
+12/3/19 8:15:24 PM Validate Start        ns>MyDescribe
+12/3/19 8:15:24 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
 Date                   Method State Result Requirement
 ----                   ------ ----- ------ -----------
-12/9/2019 5:05:38 PM     Test Start        ns>MyDescribe
-12/9/2019 5:05:38 PM     Test  Stop False  ns>MyDescribe
-12/9/2019 5:05:38 PM      Set Start        ns>MyDescribe
-12/9/2019 5:05:38 PM      Set  Stop True   ns>MyDescribe
-12/9/2019 5:05:38 PM Validate Start        ns>MyDescribe
-12/9/2019 5:05:38 PM Validate  Stop True   ns>MyDescribe
+12/9/2019 5:11:10 PM     Test Start        ns>MyDescribe
+12/9/2019 5:11:10 PM     Test  Stop False  ns>MyDescribe
+12/9/2019 5:11:10 PM      Set Start        ns>MyDescribe
+12/9/2019 5:11:10 PM      Set  Stop True   ns>MyDescribe
+12/9/2019 5:11:10 PM Validate Start        ns>MyDescribe
+12/9/2019 5:11:10 PM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Table.TestSet.txt
+++ b/test/integration/Format-Table.TestSet.txt
@@ -1,10 +1,10 @@
 
-Date                 Method State Result Requirement
-----                 ------ ----- ------ -----------
-12/2/19 9:44:13 PM     Test Start        ns>MyDescribe
-12/2/19 9:44:13 PM     Test  Stop False  ns>MyDescribe
-12/2/19 9:44:13 PM      Set Start        ns>MyDescribe
-12/2/19 9:44:13 PM      Set  Stop True   ns>MyDescribe
-12/2/19 9:44:13 PM Validate Start        ns>MyDescribe
-12/2/19 9:44:13 PM Validate  Stop True   ns>MyDescribe
+Date                  Method State Result Requirement
+----                  ------ ----- ------ -----------
+12/3/19 11:58:32 AM     Test Start        ns>MyDescribe
+12/3/19 11:58:32 AM     Test  Stop False  ns>MyDescribe
+12/3/19 11:58:32 AM      Set Start        ns>MyDescribe
+12/3/19 11:58:32 AM      Set  Stop True   ns>MyDescribe
+12/3/19 11:58:32 AM Validate Start        ns>MyDescribe
+12/3/19 11:58:32 AM Validate  Stop True   ns>MyDescribe
 

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-03 12:00:57 Set      Start ns>MyDescribe
-2019-12-03 12:00:57 Set      Stop  ns>MyDescribe
+2019-12-03 12:29:47 Set      Start ns>MyDescribe
+2019-12-03 12:29:47 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-03 11:58:32 Set      Start ns>MyDescribe
-2019-12-03 11:58:32 Set      Stop  ns>MyDescribe
+2019-12-03 12:00:57 Set      Start ns>MyDescribe
+2019-12-03 12:00:57 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-03 12:29:47 Set      Start ns>MyDescribe
-2019-12-03 12:29:47 Set      Stop  ns>MyDescribe
+2019-12-03 20:02:37 Set      Start ns>MyDescribe
+2019-12-03 20:02:37 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-03 20:02:37 Set      Start ns>MyDescribe
-2019-12-03 20:02:37 Set      Stop  ns>MyDescribe
+2019-12-03 20:15:24 Set      Start ns>MyDescribe
+2019-12-03 20:15:24 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-02 21:44:13 Set      Start ns>MyDescribe
-2019-12-02 21:44:13 Set      Stop  ns>MyDescribe
+2019-12-03 11:58:32 Set      Start ns>MyDescribe
+2019-12-03 11:58:32 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-11-26 20:21:28 Set      Start ns>MyDescribe
-2019-11-26 20:21:28 Set      Stop  ns>MyDescribe
+2019-12-02 21:44:13 Set      Start ns>MyDescribe
+2019-12-02 21:44:13 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-09 17:05:38 Set      Start ns>MyDescribe
-2019-12-09 17:05:38 Set      Stop  ns>MyDescribe
+2019-12-09 17:11:10 Set      Start ns>MyDescribe
+2019-12-09 17:11:10 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-03 20:15:24 Set      Start ns>MyDescribe
-2019-12-03 20:15:24 Set      Stop  ns>MyDescribe
+2019-12-09 17:05:38 Set      Start ns>MyDescribe
+2019-12-09 17:05:38 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Set.txt
+++ b/test/integration/Format-Verbose.Set.txt
@@ -1,2 +1,2 @@
-2019-12-09 17:11:10 Set      Start ns>MyDescribe
-2019-12-09 17:11:10 Set      Stop  ns>MyDescribe
+2019-12-09 17:16:31 Set      Start ns>MyDescribe
+2019-12-09 17:16:31 Set      Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-03 11:58:32 Test     Start ns>MyDescribe
-2019-12-03 11:58:32 Test     Stop  ns>MyDescribe
+2019-12-03 12:00:57 Test     Start ns>MyDescribe
+2019-12-03 12:00:57 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-03 12:00:57 Test     Start ns>MyDescribe
-2019-12-03 12:00:57 Test     Stop  ns>MyDescribe
+2019-12-03 12:29:47 Test     Start ns>MyDescribe
+2019-12-03 12:29:47 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-03 20:15:24 Test     Start ns>MyDescribe
-2019-12-03 20:15:24 Test     Stop  ns>MyDescribe
+2019-12-09 17:05:38 Test     Start ns>MyDescribe
+2019-12-09 17:05:38 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-02 21:44:13 Test     Start ns>MyDescribe
-2019-12-02 21:44:13 Test     Stop  ns>MyDescribe
+2019-12-03 11:58:32 Test     Start ns>MyDescribe
+2019-12-03 11:58:32 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-09 17:11:10 Test     Start ns>MyDescribe
-2019-12-09 17:11:10 Test     Stop  ns>MyDescribe
+2019-12-09 17:16:31 Test     Start ns>MyDescribe
+2019-12-09 17:16:31 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-03 20:02:37 Test     Start ns>MyDescribe
-2019-12-03 20:02:37 Test     Stop  ns>MyDescribe
+2019-12-03 20:15:24 Test     Start ns>MyDescribe
+2019-12-03 20:15:24 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-03 12:29:47 Test     Start ns>MyDescribe
-2019-12-03 12:29:47 Test     Stop  ns>MyDescribe
+2019-12-03 20:02:37 Test     Start ns>MyDescribe
+2019-12-03 20:02:37 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-11-26 20:21:27 Test     Start ns>MyDescribe
-2019-11-26 20:21:27 Test     Stop  ns>MyDescribe
+2019-12-02 21:44:13 Test     Start ns>MyDescribe
+2019-12-02 21:44:13 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.Test.txt
+++ b/test/integration/Format-Verbose.Test.txt
@@ -1,2 +1,2 @@
-2019-12-09 17:05:38 Test     Start ns>MyDescribe
-2019-12-09 17:05:38 Test     Stop  ns>MyDescribe
+2019-12-09 17:11:10 Test     Start ns>MyDescribe
+2019-12-09 17:11:10 Test     Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-03 20:15:24 Test     Start ns>MyDescribe
-2019-12-03 20:15:24 Test     Stop  ns>MyDescribe
-2019-12-03 20:15:24 Set      Start ns>MyDescribe
-2019-12-03 20:15:24 Set      Stop  ns>MyDescribe
-2019-12-03 20:15:24 Validate Start ns>MyDescribe
-2019-12-03 20:15:24 Validate Stop  ns>MyDescribe
+2019-12-09 17:05:38 Test     Start ns>MyDescribe
+2019-12-09 17:05:38 Test     Stop  ns>MyDescribe
+2019-12-09 17:05:38 Set      Start ns>MyDescribe
+2019-12-09 17:05:38 Set      Stop  ns>MyDescribe
+2019-12-09 17:05:38 Validate Start ns>MyDescribe
+2019-12-09 17:05:38 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-03 12:29:47 Test     Start ns>MyDescribe
-2019-12-03 12:29:47 Test     Stop  ns>MyDescribe
-2019-12-03 12:29:47 Set      Start ns>MyDescribe
-2019-12-03 12:29:47 Set      Stop  ns>MyDescribe
-2019-12-03 12:29:47 Validate Start ns>MyDescribe
-2019-12-03 12:29:47 Validate Stop  ns>MyDescribe
+2019-12-03 20:02:37 Test     Start ns>MyDescribe
+2019-12-03 20:02:37 Test     Stop  ns>MyDescribe
+2019-12-03 20:02:37 Set      Start ns>MyDescribe
+2019-12-03 20:02:37 Set      Stop  ns>MyDescribe
+2019-12-03 20:02:37 Validate Start ns>MyDescribe
+2019-12-03 20:02:37 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-02 21:44:13 Test     Start ns>MyDescribe
-2019-12-02 21:44:13 Test     Stop  ns>MyDescribe
-2019-12-02 21:44:13 Set      Start ns>MyDescribe
-2019-12-02 21:44:13 Set      Stop  ns>MyDescribe
-2019-12-02 21:44:13 Validate Start ns>MyDescribe
-2019-12-02 21:44:13 Validate Stop  ns>MyDescribe
+2019-12-03 11:58:32 Test     Start ns>MyDescribe
+2019-12-03 11:58:32 Test     Stop  ns>MyDescribe
+2019-12-03 11:58:32 Set      Start ns>MyDescribe
+2019-12-03 11:58:32 Set      Stop  ns>MyDescribe
+2019-12-03 11:58:32 Validate Start ns>MyDescribe
+2019-12-03 11:58:32 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-09 17:05:38 Test     Start ns>MyDescribe
-2019-12-09 17:05:38 Test     Stop  ns>MyDescribe
-2019-12-09 17:05:38 Set      Start ns>MyDescribe
-2019-12-09 17:05:38 Set      Stop  ns>MyDescribe
-2019-12-09 17:05:38 Validate Start ns>MyDescribe
-2019-12-09 17:05:38 Validate Stop  ns>MyDescribe
+2019-12-09 17:11:10 Test     Start ns>MyDescribe
+2019-12-09 17:11:10 Test     Stop  ns>MyDescribe
+2019-12-09 17:11:10 Set      Start ns>MyDescribe
+2019-12-09 17:11:10 Set      Stop  ns>MyDescribe
+2019-12-09 17:11:10 Validate Start ns>MyDescribe
+2019-12-09 17:11:10 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-03 12:00:57 Test     Start ns>MyDescribe
-2019-12-03 12:00:57 Test     Stop  ns>MyDescribe
-2019-12-03 12:00:57 Set      Start ns>MyDescribe
-2019-12-03 12:00:57 Set      Stop  ns>MyDescribe
-2019-12-03 12:00:57 Validate Start ns>MyDescribe
-2019-12-03 12:00:57 Validate Stop  ns>MyDescribe
+2019-12-03 12:29:47 Test     Start ns>MyDescribe
+2019-12-03 12:29:47 Test     Stop  ns>MyDescribe
+2019-12-03 12:29:47 Set      Start ns>MyDescribe
+2019-12-03 12:29:47 Set      Stop  ns>MyDescribe
+2019-12-03 12:29:47 Validate Start ns>MyDescribe
+2019-12-03 12:29:47 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-03 11:58:32 Test     Start ns>MyDescribe
-2019-12-03 11:58:32 Test     Stop  ns>MyDescribe
-2019-12-03 11:58:32 Set      Start ns>MyDescribe
-2019-12-03 11:58:32 Set      Stop  ns>MyDescribe
-2019-12-03 11:58:32 Validate Start ns>MyDescribe
-2019-12-03 11:58:32 Validate Stop  ns>MyDescribe
+2019-12-03 12:00:57 Test     Start ns>MyDescribe
+2019-12-03 12:00:57 Test     Stop  ns>MyDescribe
+2019-12-03 12:00:57 Set      Start ns>MyDescribe
+2019-12-03 12:00:57 Set      Stop  ns>MyDescribe
+2019-12-03 12:00:57 Validate Start ns>MyDescribe
+2019-12-03 12:00:57 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-03 20:02:37 Test     Start ns>MyDescribe
-2019-12-03 20:02:37 Test     Stop  ns>MyDescribe
-2019-12-03 20:02:37 Set      Start ns>MyDescribe
-2019-12-03 20:02:37 Set      Stop  ns>MyDescribe
-2019-12-03 20:02:37 Validate Start ns>MyDescribe
-2019-12-03 20:02:37 Validate Stop  ns>MyDescribe
+2019-12-03 20:15:24 Test     Start ns>MyDescribe
+2019-12-03 20:15:24 Test     Stop  ns>MyDescribe
+2019-12-03 20:15:24 Set      Start ns>MyDescribe
+2019-12-03 20:15:24 Set      Stop  ns>MyDescribe
+2019-12-03 20:15:24 Validate Start ns>MyDescribe
+2019-12-03 20:15:24 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-11-26 20:21:27 Test     Start ns>MyDescribe
-2019-11-26 20:21:27 Test     Stop  ns>MyDescribe
-2019-11-26 20:21:27 Set      Start ns>MyDescribe
-2019-11-26 20:21:27 Set      Stop  ns>MyDescribe
-2019-11-26 20:21:27 Validate Start ns>MyDescribe
-2019-11-26 20:21:27 Validate Stop  ns>MyDescribe
+2019-12-02 21:44:13 Test     Start ns>MyDescribe
+2019-12-02 21:44:13 Test     Stop  ns>MyDescribe
+2019-12-02 21:44:13 Set      Start ns>MyDescribe
+2019-12-02 21:44:13 Set      Stop  ns>MyDescribe
+2019-12-02 21:44:13 Validate Start ns>MyDescribe
+2019-12-02 21:44:13 Validate Stop  ns>MyDescribe

--- a/test/integration/Format-Verbose.TestSet.txt
+++ b/test/integration/Format-Verbose.TestSet.txt
@@ -1,6 +1,6 @@
-2019-12-09 17:11:10 Test     Start ns>MyDescribe
-2019-12-09 17:11:10 Test     Stop  ns>MyDescribe
-2019-12-09 17:11:10 Set      Start ns>MyDescribe
-2019-12-09 17:11:10 Set      Stop  ns>MyDescribe
-2019-12-09 17:11:10 Validate Start ns>MyDescribe
-2019-12-09 17:11:10 Validate Stop  ns>MyDescribe
+2019-12-09 17:16:31 Test     Start ns>MyDescribe
+2019-12-09 17:16:31 Test     Stop  ns>MyDescribe
+2019-12-09 17:16:31 Set      Start ns>MyDescribe
+2019-12-09 17:16:31 Set      Stop  ns>MyDescribe
+2019-12-09 17:16:31 Validate Start ns>MyDescribe
+2019-12-09 17:16:31 Validate Stop  ns>MyDescribe

--- a/test/interface.tests.ps1
+++ b/test/interface.tests.ps1
@@ -112,6 +112,7 @@ Describe "New-RequirementGroup" {
       @{Namespace = "req1" },
       @{Namespace = "req2" }
     )
+
     New-RequirementGroup -Namespace $namespace -Requirement $requirements `
     | % { $_.Namespace | Should -BeLikeExactly "$namespace`:*" }
   }

--- a/test/interface.tests.ps1
+++ b/test/interface.tests.ps1
@@ -5,6 +5,7 @@ $RepoRoot = "$PSScriptRoot/.."
 $SourceRoot = "$RepoRoot/src"
 ."$SourceRoot\interface.ps1"
 
+# Detect Admin on downlevel Powershell
 $PlatformLacksDscSupport = $PSVersionTable.PSEdition -eq "Core"
 if (-not $PlatformLacksDscSupport) {
   $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()

--- a/test/interface.tests.ps1
+++ b/test/interface.tests.ps1
@@ -104,14 +104,14 @@ Describe "Set-Requirement" {
   }
 }
 
-Describe "Push-Namespace" {
+Describe "New-RequirementGroup" {
   It "Should prepend the namespace to the requirements" {
     $namespace = "MyReqs"
     $requirements = @(
       @{Namespace = "req1" },
       @{Namespace = "req2" }
     )
-    Push-Namespace -Namespace $namespace -Requirement $requirements `
+    New-RequirementGroup -Namespace $namespace -Requirement $requirements `
     | % { $_.Namespace | Should -BeLikeExactly "$namespace`:*" }
   }
 }


### PR DESCRIPTION
This change reflects a more intuitive naming to better describe the intent of groups of requirements. 

- `New` verb instead of `Push`, because groups are not conceptually a stack.
- `RequirementGroup` instead of `Namespace`, so we do not imply reusability by itself.

Note:
- I have left the internal Namespace parameter alone, as it still makes sense to have a namespace, just not to refer to a group by one.
- I have added an Alias in case anyone is using `Push-Namespace` already.

Further, I updated documentation to reflect this change and illustrate how to properly Invoke a RequirementGroup.  I also cleaned up a lot of markdownlint errors in Readme.